### PR TITLE
add toggle to hide/show section background

### DIFF
--- a/config/package-solution.json
+++ b/config/package-solution.json
@@ -24,12 +24,12 @@
         "title": "People Search Feature",
         "description": "The feature that activates elements of the spfx-msgraph-peoplesearch solution.",
         "id": "e09916bd-8e2e-4220-8d05-60d3a6f4d98b",
-        "version": "2.8.0.0"
+        "version": "2.8.1.0"
       }
     ],
     "name": "Microsoft Graph People Search",
     "id": "98a8d9d1-47c4-477c-addd-ecae95b235cc",
-    "version": "2.8.0.0",
+    "version": "2.8.1.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
     "isDomainIsolated": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spfx-msgraph-peoplesearch",
-  "version": "2.7.1",
+  "version": "2.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spfx-msgraph-peoplesearch",
-      "version": "2.7.1",
+      "version": "2.8.1",
       "dependencies": {
         "@fluentui/react": "^8.106.4",
         "@microsoft/sp-component-base": "1.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spfx-msgraph-peoplesearch",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "private": true,
   "engines": {
     "node": ">=16.13.0 <17.0.0 || >=18.17.1 <19.0.0"

--- a/src/webparts/peoplesearch/IPeopleSearchWebPartProps.ts
+++ b/src/webparts/peoplesearch/IPeopleSearchWebPartProps.ts
@@ -13,6 +13,7 @@ export interface IPeopleSearchWebPartProps {
   showPagination: boolean;
   showLPC: boolean;
   showResultsCount: boolean;
+  showBackground: boolean;
   showBlank: boolean;
   hideResultsOnload: boolean;
   selectedLayout: ResultsLayoutOption;

--- a/src/webparts/peoplesearch/PeopleSearchWebPart.ts
+++ b/src/webparts/peoplesearch/PeopleSearchWebPart.ts
@@ -80,6 +80,7 @@ export default class PeopleSearchWebPart extends BaseClientSideWebPart<IPeopleSe
         {
           webPartTitle: this.properties.webPartTitle,
           displayMode: this.displayMode,
+          showBackground: this.properties.showBackground,
           showBlank: this.properties.showBlank,
           hideResultsOnload: this.properties.hideResultsOnload,
           showResultsCount: this.properties.showResultsCount,
@@ -320,6 +321,10 @@ export default class PeopleSearchWebPart extends BaseClientSideWebPart<IPeopleSe
     ] as IPropertyPaneChoiceGroupOption[];
 
     const stylingFields: IPropertyPaneField<any>[] = [ // eslint-disable-line @typescript-eslint/no-explicit-any
+      PropertyPaneToggle('showBackground', {
+        label: strings.ShowBackgroundLabel,
+        checked: this.properties.showBackground
+      }),
       PropertyPaneToggle('showPagination', {
         label: strings.ShowPaginationControl,
       }),

--- a/src/webparts/peoplesearch/components/PeopleSearchContainer/IPeopleSearchContainerProps.ts
+++ b/src/webparts/peoplesearch/components/PeopleSearchContainer/IPeopleSearchContainerProps.ts
@@ -24,6 +24,11 @@ export interface IPeopleSearchContainerProps {
     showResultsCount: boolean;
 
     /**
+     * Webpart has transparent background allowing section background to be visible
+     */
+    showBackground: boolean;
+
+    /**
      * Show nothing if no result
      */
     showBlank: boolean;

--- a/src/webparts/peoplesearch/components/PeopleSearchContainer/PeopleSearchContainer.tsx
+++ b/src/webparts/peoplesearch/components/PeopleSearchContainer/PeopleSearchContainer.tsx
@@ -118,6 +118,7 @@ export class PeopleSearchContainer extends React.Component<IPeopleSearchContaine
           resultCount: this.state.resultCount,
           showPagination: this.props.showPagination,
           showResultsCount: this.props.showResultsCount,
+          showBackground: this.props.showBackground,
           showBlank: this.props.showBlank && this.props.searchParameterOption !== SearchParameterOption.SearchBox,
           showLPC: this.props.showLPC,
           themeVariant: this.props.themeVariant,
@@ -199,7 +200,7 @@ export class PeopleSearchContainer extends React.Component<IPeopleSearchContaine
     }
 
     return (
-      <div style={{backgroundColor: semanticColors.bodyBackground}}>
+      <div style={{backgroundColor: this.props.showBackground ? 'transparent' : semanticColors.bodyBackground}}>
         <div className={styles.peopleSearchWebPart}>
           {renderWebPartTitle}
           {renderShimmerElements ? renderShimmerElements : renderWebPartContent}

--- a/src/webparts/peoplesearch/loc/en-us.js
+++ b/src/webparts/peoplesearch/loc/en-us.js
@@ -43,5 +43,6 @@ define([], function() {
       "PersonaSizeLarge": "Large",
       "PersonaSizeExtraLarge": "Extra large",
     },
+    "ShowBackgroundLabel": "Allow section background to be visible"
   }
 });

--- a/src/webparts/peoplesearch/loc/mystrings.d.ts
+++ b/src/webparts/peoplesearch/loc/mystrings.d.ts
@@ -41,7 +41,8 @@ declare interface IPeopleSearchWebPartStrings {
     PersonaSizeRegular: string;
     PersonaSizeLarge: string;
     PersonaSizeExtraLarge: string;
-  }
+  },
+  ShowBackgroundLabel: string;
 }
 
 declare module 'PeopleSearchWebPartStrings' {


### PR DESCRIPTION
|        Q                  |            A            |
| ----------------    | ----------------- |
| Bug fix?               | no                      |
| New feature?      | yes                     |
| Doc fix                | no                       |
| Related issues?   | mentioned #90  |

## What's in this Pull Request?
A toggle is added to the property pane controls, setting a boolean value
This value is passed into the webpart
If the value is true, then the background color of the PeopleSearchContainer will be transparent
If the value is false, then it defaults to what it was originally `semanticColors.bodyBackround`
Other changes include adding location string data for the new property pane control